### PR TITLE
Bug Fix: on MacOS Array.findLast is not implemented, use polyfill

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,8 @@ How to Use
    __ https://docs.ankiweb.net/media.html#manually-adding-media
 
 #. Create a new note type by cloning the built-in Cloze.
-#. Add a rendering configuration field named ``Before|After|OnlyContext|RevealAll|InactiveHints``.
+#. Rename the field ``Back Extra`` to ``Extra``
+#. Add a rendering configuration field named ``Settings`` whose value you can set as to a comma separated list corresponding to ``Before,After,OnlyContext,RevealAll,InactiveHints``.
 #. Put the content of `<front.template.anki>`_ into note's Front Template.
 #. Put the content of `<back.template.anki>`_ into note's Back Template.
 #. (Optional AnkiDroid compatibility) Add
@@ -49,8 +50,8 @@ How to Use
 Rendering Configuration
 -----------------------
 
-Template's field ``Before|After|OnlyContext|RevealAll|InactiveHints`` controls the rendering
-of clozes. Individual parameters are separated by either spaces, commas, pipes or dots.
+Template's field ``Settings`` whose value you can set as to a comma separated list corresponding to ``Before,After,OnlyContext,RevealAll,InactiveHints``
+controls the rendering of clozes. Individual parameters are separated by either spaces, commas, pipes or dots.
 Omitted rightmost parameters all take default values.
 
 The parameters are as follows:
@@ -64,8 +65,11 @@ The parameters are as follows:
 ``OnlyContext`` (Boolean ``true`` or ``false``, defaults to ``false``)
   Show clozes only within the context (before + current + after).
   Set to ``true`` for e.g. long lyrics/poems.
+  e.g. ``{{c1::A}} {{c2::B}} {{c3::C}} {{c4::D}} {{c5::E}}`` with ``1,1,true`` and current Cloze on ``c3``, you will see
+  ``B [...] D`` instead of ``[...] B [...] D [...]`` 
+  
 
-``RevelAll`` (Boolean ``true`` or ``false``, defaults to ``false``)
+``RevealAll`` (Boolean ``true`` or ``false``, defaults to ``false``)
   Reveal all clozes on the back of the card. By default, only currently active clozes are revealed.
   (Context clozes are revealed even on cards' fronts.)
 

--- a/_cloze-overlapper.js
+++ b/_cloze-overlapper.js
@@ -1,3 +1,21 @@
+// Anki 2.1 on MacOS 14.2 Sonoma, Array.findLast is not implemented, use polyfill from below
+// https://medium.com/@stheodorejohn/findlast-method-polyfill-in-javascript-bridging-browser-gaps-c3baf6aabae1
+if (!Array.prototype.findLast) {
+  Array.prototype.findLast = function(callback) {
+    if (this == null) {
+      throw new TypeError('this is null or not defined');
+    }
+    const arr = Object(this);
+    const len = arr.length >>> 0;
+    for (let i = len - 1; i >= 0; i--) {
+      if (callback(arr[i], i, arr)) {
+        return arr[i];
+      }
+    }
+    return undefined;
+  };
+}
+
 /**
  * @param {number} begin
  * @param {number} [end]

--- a/_cloze-overlapper.js
+++ b/_cloze-overlapper.js
@@ -1,5 +1,3 @@
-// Anki 2.1 on MacOS 14.2 Sonoma, Array.findLast is not implemented, use polyfill from below
-// https://medium.com/@stheodorejohn/findlast-method-polyfill-in-javascript-bridging-browser-gaps-c3baf6aabae1
 if (!Array.prototype.findLast) {
   Array.prototype.findLast = function(callback) {
     if (this == null) {
@@ -681,7 +679,7 @@ const CONFIG_SPLIT_RE = /[,\s|.]+/;
  */
 function parseConfig(elementId = 'cloze-config') {
     const config = /** @type {string} */ (
-        /** @type {HTMLTemplateElement} */ (document.getElementById(elementId)).content.textContent
+        /** @type {HTMLTemplateElement} */ (document.getElementById(elementId)).content.textContent.trim()
     ).split(CONFIG_SPLIT_RE);
 
     return {

--- a/back.template.anki
+++ b/back.template.anki
@@ -1,7 +1,7 @@
 <cloze-generator></cloze-generator>
 
 <template id="anki-cloze">{{cloze:Text}}</template>
-<template id="cloze-config">{{Before|After|OnlyContext|RevealAll|InactiveHints}}</template>
+<template id="cloze-config">{{Settings}}</template>
 <template id="cloze-source">
 	<!--
     Uncomment and adjust if MathJax style autodetection doesn't work for you.
@@ -15,7 +15,7 @@
   {{Text}}
 </template>
 <div id="rendered-cloze"></div>
-{{Back Extra}}
+{{Extra}}
 
 <div>
   <button id="reveal-all-button" hidden>Reveal All</button>

--- a/front.template.anki
+++ b/front.template.anki
@@ -1,7 +1,7 @@
 <cloze-generator></cloze-generator>
 
 <template id="anki-cloze">{{cloze:Text}}</template>
-<template id="cloze-config">{{Before|After|OnlyContext|RevealAll|InactiveHints}}</template>
+<template id="cloze-config">{{Settings}}</template>
 <template id="cloze-source">
 	<!--
     Uncomment and adjust if MathJax style autodetection doesn't work for you.


### PR DESCRIPTION
Thanks for the work! 
I found that on on MacOS 14.2 anki 2.1, I need a polyfill for Array.findLast